### PR TITLE
feat(tiler): Export, also, TileServer

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 import { TileServer } from './tiler';
 export * from '../types';
 export default TileServer;
+export { TileServer };


### PR DESCRIPTION
For some reason, in typescript I got the following scenarios:

```ts
import TileServer from 'clusterbuster';
```
In this one, TileServer was `undefined`.

```ts
import * as TileServer from 'clusterbuster';
```

In this one I got the following compile error: `Cannot invoke an expression whose type lacks a call signature. Type 'typeof import("clusterbuster/dist/index")' has no compatible call signatures.`.

With this PR, you can do it like:

```ts
import { TileServer } from 'clusterbuster';
```