### PR TITLE
feat(tiler): Replace resolution with extent and bufferSize

### DIFF
--- a/lib/__test__/__snapshots__/queries.test.ts.snap
+++ b/lib/__test__/__snapshots__/queries.test.ts.snap
@@ -177,10 +177,10 @@ exports[`createClusterQuery should create a clustered Query 1`] = `
      WHERE ST_Intersects(TileBBox($4, $5, $6, 3857), ST_Transform(center, 3857))),
      q as
     (SELECT 1 as c1,
-            ST_AsMVTGeom(ST_Transform(center, 3857), TileBBox($7, $8, $9, 3857), $10, 10, false) AS geom,
+            ST_AsMVTGeom(ST_Transform(center, 3857), TileBBox($7, $8, $9, 3857), $10, $11, false) AS geom,
             jsonb_build_object('count', theCount, 'expansionZoom', expansionZoom, 'a', a) as attributes
      FROM tiled)
-SELECT ST_AsMVT(q, $11, $12, 'geom') as mvt
+SELECT ST_AsMVT(q, $12, $13, 'geom') as mvt
 from q
 "
 `;
@@ -196,9 +196,10 @@ Array [
   1,
   0,
   1,
-  512,
+  4096,
+  256,
   "points",
-  512,
+  4096,
 ]
 `;
 
@@ -213,10 +214,10 @@ WITH filtered AS
     ),
     q as
     (SELECT 1 as c1,
-            ST_AsMVTGeom(ST_Transform(wkb_geometry, 3857), TileBBox($4, $5, $6, 3857), $7, 10, false) AS geom,
+            ST_AsMVTGeom(ST_Transform(wkb_geometry, 3857), TileBBox($4, $5, $6, 3857), $7, $8, false) AS geom,
             jsonb_build_object('count', 1, 'expansionZoom', 10, 'a', a) AS attributes
      FROM filtered)
-SELECT ST_AsMVT(q, $8, $9, 'geom') as mvt
+SELECT ST_AsMVT(q, $9, $10, 'geom') as mvt
 from q
 ",
   "type": "SLONIK_TOKEN_SQL",
@@ -227,9 +228,10 @@ from q
     15,
     0,
     1,
-    512,
+    4096,
+    256,
     "points",
-    512,
+    4096,
   ],
 }
 `;

--- a/lib/__test__/queries.test.ts
+++ b/lib/__test__/queries.test.ts
@@ -10,16 +10,13 @@ describe('createClusterQuery', () => {
       geometry: 'wkb_geometry',
       sourceLayer: 'points',
       maxZoomLevel: 10,
-      resolution: 512,
+      extent: 4096,
+      bufferSize: 256,
       attributes: ['a'],
       query: ['status = status', '[1, 2] @> [2, 3]'],
     });
-    expect(
-      query.sql
-    ).toMatchSnapshot();
-    expect(
-      query.values
-    ).toMatchSnapshot();
+    expect(query.sql).toMatchSnapshot();
+    expect(query.values).toMatchSnapshot();
   });
 
   it('should create a unclustered Query', () => {
@@ -32,7 +29,8 @@ describe('createClusterQuery', () => {
         geometry: 'wkb_geometry',
         sourceLayer: 'points',
         maxZoomLevel: 10,
-        resolution: 512,
+        extent: 4096,
+        bufferSize: 256,
         attributes: ['a'],
         query: [],
       })

--- a/lib/tiler.ts
+++ b/lib/tiler.ts
@@ -7,7 +7,6 @@ import { zip } from './zip';
 
 export async function TileServer<T>({
   maxZoomLevel = 12,
-  resolution = 512,
   cacheOptions = defaultCacheOptions,
   pgPoolOptions = {},
   filtersToWhere = null,
@@ -35,6 +34,8 @@ export async function TileServer<T>({
     geometry = 'wkb_geometry',
     sourceLayer = 'points',
     radius = 20,
+    extent = 4096,
+    bufferSize = 256,
     queryParams = {},
     id = '',
   }: TileInput<T>) => {
@@ -63,7 +64,8 @@ export async function TileServer<T>({
           table,
           geometry,
           sourceLayer,
-          resolution,
+          extent,
+          bufferSize,
           attributes,
           query: filtersQuery,
           debug,

--- a/lib/tiler.ts
+++ b/lib/tiler.ts
@@ -7,6 +7,7 @@ import { zip } from './zip';
 
 export async function TileServer<T>({
   maxZoomLevel = 12,
+  resolution = 512,
   cacheOptions = defaultCacheOptions,
   pgPoolOptions = {},
   filtersToWhere = null,

--- a/lib/types/IQueryInput.ts
+++ b/lib/types/IQueryInput.ts
@@ -7,6 +7,8 @@ export interface IQueryInput extends TileRequest {
   sourceLayer: string;
   radius: number;
   resolution: number;
+  extent: number;
+  bufferSize: number;
   attributes: string[];
   query: string[];
   debug: boolean;

--- a/types/TileInput.ts
+++ b/types/TileInput.ts
@@ -25,6 +25,16 @@ export interface TileInput<T> extends TileRequest {
   radius?: number;
 
   /**
+   * @description The tile extent. Here the grid dimensions will be 4096x4096
+   */
+  extent?: number;
+
+  /**
+   * @description The buffer size. Here we'll have a margin of 256 grid cells in addition to the tile extent.
+   */
+  bufferSize?: number;
+
+  /**
    * @description The query parameters used to filter
    */
   queryParams?: T | {};

--- a/types/TileInput.ts
+++ b/types/TileInput.ts
@@ -25,12 +25,14 @@ export interface TileInput<T> extends TileRequest {
   radius?: number;
 
   /**
-   * @description The tile extent. Here the grid dimensions will be 4096x4096
+   * @description The tile extent is the grid dimension value as specified by ST_AsMVT. The default is 4096.
+   * @see https://postgis.net/docs/ST_AsMVT.html
    */
   extent?: number;
 
   /**
-   * @description The buffer size. Here we'll have a margin of 256 grid cells in addition to the tile extent.
+   * @description The buffer around the tile extent in the number of grid cells as specified by ST_AsMVT. The default is 256.
+   * @see https://postgis.net/docs/ST_AsMVT.html
    */
   bufferSize?: number;
 

--- a/types/TileServerConfig.ts
+++ b/types/TileServerConfig.ts
@@ -12,12 +12,6 @@ export interface TileServerConfig<T> {
   maxZoomLevel?: number;
 
   /**
-   * @description The tile resolution in pixels, default is 512, but try 256 if you
-   * are unsure what your mapping front-end library uses
-   */
-  resolution?: number;
-
-  /**
    * @description LRU tile cache options, each tile request is stored in this cache.
    * clusterbuster tries to provide sane defaults
    */

--- a/types/TileServerConfig.ts
+++ b/types/TileServerConfig.ts
@@ -12,6 +12,13 @@ export interface TileServerConfig<T> {
   maxZoomLevel?: number;
 
   /**
+   * @description The tile resolution in pixels, default is 512, but try 256 if you
+   * are unsure what your mapping front-end library uses
+   * @deprecated This is ignored and will be removed in future releases
+   */
+  resolution?: number;
+
+  /**
    * @description LRU tile cache options, each tile request is stored in this cache.
    * clusterbuster tries to provide sane defaults
    */


### PR DESCRIPTION
Now you can configure the MVT extent and buffer size and avoid rounding issues.
Here is an example of how to make MVT from PostGIS: https://blog.jawg.io/how-to-make-mvt-with-postgis/